### PR TITLE
Whitepapers: Cross-Link Secondary Categories

### DIFF
--- a/docs/source/papers/submitted.rst
+++ b/docs/source/papers/submitted.rst
@@ -1,22 +1,35 @@
 .. _papers-submitted:
 
-Submitted to CompF2: Theoretical Calculations and Simulation
-============================================================
+Submitted
+=========
 
 We rely on the community (you) to inform us about proposed and submitted papers by sending emails to AccBeamModelSnowmass21@lbl.gov.
 
+To the Computational Frontier (CompF)
+"""""""""""""""""""""""""""""""""""""
+
 - **CompF2: Theoretical Calculations and Simulation (also under AF0):** *Snowmass21 Accelerator Modeling Community White Paper* by the Snowmass Accelerator & beam physics modeling interest group in the topical group Theoretical Calculations and Simulation (CompF2) (2022), `arXiv:2203.08335 <https://arxiv.org/abs/2203.08335>`__
+
+`All Theoretical calculations and simulation (CompF02) submissions <https://snowmass21.org/submissions/compf#compf02theoretical_calculations_and_simulation>`__.
 
 `All Computational Frontier (CompF) submissions <https://snowmass21.org/submissions/compf>`__.
 
 
-Related Whitepapers in Accelerator Science and Technology (AF) from members of our Interest Group
+Related Whitepapers in Accelerator Science and Technology (AF) from Members of our Interest Group
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
-
-`All Accelerator Science and Technology (AF) submissions <https://snowmass21.org/submissions/af>`__.
 
 - **AF0 (also under CommF01):** *Nurturing the Industrial Accelerator Technology Base in the US* by A.M.M. Todd, R. Agustsson, D.L. Bruhwiler, J. Chunguang, S.C. Gottschalk, A. Kanareykin, A. Murokh, J. W. Rathke, M. Ruelas, V. Yakovlev and K. Yoshimura (2022), `arXiv:2203.10377 <https://arxiv.org/abs/2203.10377>`__
 
-- **AF06: Advanced accelerator concepts (also under EF09, CompF02):** *PetaVolts per meter Plasmonics: Snowmass21 White Paper* by A.A. Sahai, M. Golkowski, S. Gedney, T. Katsouleas, G. Andonian, G. White, J. Stohr, P. Muggli, D. Filipetto, F. Zimmermann, T. Tajima, G. Mourou, J. Resta-Lopez -  (2022), `arXiv:2203.11623 <https://arxiv.org/abs/2203.11623>`__
+- **AF06: Advanced accelerator concepts (also under EF09, CompF02):** *PetaVolts per meter Plasmonics: Snowmass21 White Paper* by A.A. Sahai, M. Golkowski, S. Gedney, T. Katsouleas, G. Andonian, G. White, J. Stohr, P. Muggli, D. Filipetto, F. Zimmermann, T. Tajima, G. Mourou, J. Resta-Lopez (2022), `arXiv:2203.11623 <https://arxiv.org/abs/2203.11623>`__
 
 - **AF06: Advanced accelerator concepts:** *Linear collider based on laser-plasma accelerators* by C. Benedetti, S.S. Bulanov, E. Esarey, C.G.R. Geddes, A.J. Gonsalves, A. Huebl, R. Lehe, K. Nakamura, C. B. Schroeder, D. Terzani, J. van Tilborg, M. Turner, J.-L. Vay, T. Zhou, F. Albert, J. Bromage, E.M. Campbell, D.H. Froula, J. P. Palastro, J. Zuegel, D. Bruhwiler, N.M. Cook, B. Cros, M.C. Downer, M. Fuchs, B.A. Shadwick, S.J. Gessner, M.J. Hogan, S.M. Hooker, C. Jing, K. Krushelnick, A. G.R. Thomas, W.P. Leemans, A.R. Maier, J. Osterhoff, K. Poder, M. Thevenet, W.B. Mori, M. Palmer, J.G. Power, N. Vafaei-Najafabadi (2022), `arXiv:2203.08366 <https://arxiv.org/abs/2203.08366>`__
+
+`All Accelerator Science and Technology (AF) submissions <https://snowmass21.org/submissions/af>`__.
+
+
+Related Whitepapers in the Theory Frontier (TF) from Members of our Interest Group
+""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+
+- **TF07: Collider Phenomenology in the Theory Frontier (also under CompF7):** *Data and Analysis Preservation, Recasting, and Reinterpretation* by S. Bailey, C. Bierlich, A. Buckley, J. Butterworth, K. Cranmer, M. Feickert, L. Heinrich, A. Huebl, S. Kraml, A. Kvellestad, C. Lange, A. Lessa, K. Lassila-Perini, C. Nattrass, M.S. Neubauer, S. Sekmen, G. Stark, G. Watt (2022), `arXiv:2203.10057 <https://arxiv.org/abs/2203.10057>`__
+
+`All Theory Frontier (TF) submissions <https://snowmass21.org/submissions/tf>`__.

--- a/docs/source/papers/submitted.rst
+++ b/docs/source/papers/submitted.rst
@@ -1,8 +1,22 @@
 .. _papers-submitted:
 
-Submitted
-=========
+Submitted to CompF2: Theoretical Calculations and Simulation
+============================================================
 
 We rely on the community (you) to inform us about proposed and submitted papers by sending emails to AccBeamModelSnowmass21@lbl.gov.
 
-- **Snowmass21 Accelerator Modeling Community White Paper** - `arXiv:2203.08335 <https://arxiv.org/abs/2203.08335>`__ - *The Snowmass Accelerator & beam physics modeling interest group in the topical group Theoretical Calculations and Simulation (CompF2)*.
+- **CompF2: Theoretical Calculations and Simulation (also under AF0):** *Snowmass21 Accelerator Modeling Community White Paper* by the Snowmass Accelerator & beam physics modeling interest group in the topical group Theoretical Calculations and Simulation (CompF2) (2022), `arXiv:2203.08335 <https://arxiv.org/abs/2203.08335>`__
+
+`All Computational Frontier (CompF) submissions <https://snowmass21.org/submissions/compf>`__.
+
+
+Related Whitepapers in Accelerator Science and Technology (AF) from members of our Interest Group
+"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+
+`All Accelerator Science and Technology (AF) submissions <https://snowmass21.org/submissions/af>`__.
+
+- **AF0 (also under CommF01):** *Nurturing the Industrial Accelerator Technology Base in the US* by A.M.M. Todd, R. Agustsson, D.L. Bruhwiler, J. Chunguang, S.C. Gottschalk, A. Kanareykin, A. Murokh, J. W. Rathke, M. Ruelas, V. Yakovlev and K. Yoshimura (2022), `arXiv:2203.10377 <https://arxiv.org/abs/2203.10377>`__
+
+- **AF06: Advanced accelerator concepts (also under EF09, CompF02):** *PetaVolts per meter Plasmonics: Snowmass21 White Paper* by A.A. Sahai, M. Golkowski, S. Gedney, T. Katsouleas, G. Andonian, G. White, J. Stohr, P. Muggli, D. Filipetto, F. Zimmermann, T. Tajima, G. Mourou, J. Resta-Lopez -  (2022), `arXiv:2203.11623 <https://arxiv.org/abs/2203.11623>`__
+
+- **AF06: Advanced accelerator concepts:** *Linear collider based on laser-plasma accelerators* by C. Benedetti, S.S. Bulanov, E. Esarey, C.G.R. Geddes, A.J. Gonsalves, A. Huebl, R. Lehe, K. Nakamura, C. B. Schroeder, D. Terzani, J. van Tilborg, M. Turner, J.-L. Vay, T. Zhou, F. Albert, J. Bromage, E.M. Campbell, D.H. Froula, J. P. Palastro, J. Zuegel, D. Bruhwiler, N.M. Cook, B. Cros, M.C. Downer, M. Fuchs, B.A. Shadwick, S.J. Gessner, M.J. Hogan, S.M. Hooker, C. Jing, K. Krushelnick, A. G.R. Thomas, W.P. Leemans, A.R. Maier, J. Osterhoff, K. Poder, M. Thevenet, W.B. Mori, M. Palmer, J.G. Power, N. Vafaei-Najafabadi (2022), `arXiv:2203.08366 <https://arxiv.org/abs/2203.08366>`__


### PR DESCRIPTION
Add more whitepapers that are either using CompF2 as secondary category with accelerator/beam relation, are closely related, referenced in our whitepaper and/or written by members of our interest group.

Collected in today's meeting.